### PR TITLE
Changed random name for stars input to be more random

### DIFF
--- a/app/views/spree/reviews/_stars.html.erb
+++ b/app/views/spree/reviews/_stars.html.erb
@@ -3,7 +3,7 @@
     name  = "review[rating]"
   else
     state = 'disabled'
-    name  = defined?(review).nil? ? Time.now.tv_usec.to_s : "review_#{review}"
+    name  = defined?(review).nil? ? rand(100000) : "review_#{review}"
   end %>
 <% for i in 1..NB_STARS %>
   <input name="<%= name %>"

--- a/spree_reviews.gemspec
+++ b/spree_reviews.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_reviews'
-  s.version     = '1.0.0'
+  s.version     = '1.0.1'
   s.summary     = 'Basic review and ratings facility for Spree'
   s.authors 	  = ['Paul Callaghan']
   s.description = s.summary


### PR DESCRIPTION
This should fix the problem of the reviews with 10+ stars. The reason some would have multiple sets of stars was due to the hidden star input fields having the same name. For example,

Product 1 has star inputs like:

```
<input name="1868" type="radio" class="star star-rating-applied star-rating-readonly" value="1 stars" disabled="" style="display: none;">
<input name="1868" type="radio" class="star star-rating-applied star-rating-readonly" value="2 stars" disabled="" style="display: none;">
<input name="1868" type="radio" class="star star-rating-applied star-rating-readonly" value="3 stars" disabled="" style="display: none;">
<input name="1868" type="radio" class="star star-rating-applied star-rating-readonly" value="4 stars" disabled="" style="display: none;">
<input name="1868" type="radio" class="star star-rating-applied star-rating-readonly" value="5 stars" disabled="" style="display: none;">
```

Product 2 has star inputs like:

```
<input name="36510" type="radio" class="star star-rating-applied star-rating-readonly" value="1 stars" disabled="" style="display: none;">
<input name="36510" type="radio" class="star star-rating-applied star-rating-readonly" value="2 stars" disabled="" style="display: none;">
<input name="36510" type="radio" class="star star-rating-applied star-rating-readonly" value="3 stars" disabled="" style="display: none;">
<input name="36510" type="radio" class="star star-rating-applied star-rating-readonly" value="4 stars" disabled="" style="display: none;">
<input name="36510" type="radio" class="star star-rating-applied star-rating-readonly" value="5 stars" disabled="" style="display: none;">
```

and Product 3 has star inputs like:

```
<input name="1868" type="radio" class="star star-rating-applied star-rating-readonly" value="1 stars" disabled="" style="display: none;">
<input name="1868" type="radio" class="star star-rating-applied star-rating-readonly" value="2 stars" disabled="" style="display: none;">
<input name="1868" type="radio" class="star star-rating-applied star-rating-readonly" value="3 stars" disabled="" style="display: none;">
<input name="1868" type="radio" class="star star-rating-applied star-rating-readonly" value="4 stars" disabled="" style="display: none;">
<input name="1868" type="radio" class="star star-rating-applied star-rating-readonly" value="5 stars" disabled="" style="display: none;">
```

This would cause the stars created by jQuery.rating to create the stars twice for Product 1 and 3 making them appear that they have 10 stars. This fix should make the naming convention for these inputs more random to avoid this situation.
